### PR TITLE
Feature/png

### DIFF
--- a/postcard_creator/postcard_creator.py
+++ b/postcard_creator/postcard_creator.py
@@ -416,7 +416,7 @@ class PostcardCreator(object):
 
             cover = resizeimage.resize_cover(image, [width, height], validate=True)
             with BytesIO() as f:
-                cover.save(f, 'JPEG')
+                cover.save(f, 'PNG')
                 scaled = f.getvalue()
 
             if image_export:

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ reqs = [
 
 setup(
     name='postcard_creator',
-    version='0.0.6', #find_version('postcard_creator', '__init__.py'),
+    version='0.0.7', #find_version('postcard_creator', '__init__.py'),
     url='http://github.com/abertschi/postcard_creator_wrapper',
     license='Apache Software License',
     author='Andrin Bertschi',


### PR DESCRIPTION
Use PNG instead of JPEG internally to avoid
'OSError: cannot write mode RGBA as JPEG'
when PNGs are uploaded