### PR TITLE
Update dependency: Requests to v2.25.1

### DIFF
--- a/postcard_creator/token.py
+++ b/postcard_creator/token.py
@@ -232,8 +232,8 @@ class Token(object):
         if len(resp.history) == 0:
             raise PostcardCreatorException('fail to fetch ' + url)
 
-        step1_goto_url = resp.history[len(resp.history) - 1]
-        goto_param = re.search(r'goto=(.*?)$', step1_goto_url.url).group(1)
+        step1_goto_url = resp.history[len(resp.history) - 1].headers['Location']
+        goto_param = re.search(r'goto=(.*?)$', step1_goto_url).group(1)
         try:
             goto_param = goto_param.split('&')[0]
         except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Pillow>=7.1.0
 pluggy==0.4.0
 py==1.4.34
 python-resize-image==1.1.19
-requests==2.20.0
+requests==2.25.1
 requests-toolbelt==0.8.0
 responses==0.5.1
 six==1.10.0


### PR DESCRIPTION
After updating the dependencies, I found out that the http requests package ([requests](https://github.com/psf/requests)) introduced some breaking changes in version 24.0.0. At least I think the problem is in that version.

**The error traceback I got:**

```
Traceback (most recent call last):
  ...
  File "postcard_creator/token.py", line 123, in fetch_token
    access_token = self._get_access_token_swissid(session, username, password)
  File "postcard_creator/token.py", line 236, in _get_access_token_swissid
    goto_param = re.search(r'goto=(.*?)$', step1_goto_url.url).group(1)
AttributeError: 'NoneType' object has no attribute 'group'
```
I think the problem has something to do with the redirecting during the sign-in process, whose handling has been changed in v2.24.0. A quick change in the sign-in process fixed the issue. With the new swiss-id sign-in it works fine for now. But I have no way to test out the legacy sign-in method. Can somebody do this step?

On top of that, I let run my script for a couple of days, to catch some corner cases...