### PR TITLE
Preserve newlines while computing the text-image

### DIFF
--- a/postcard_creator/postcard_img_util.py
+++ b/postcard_creator/postcard_img_util.py
@@ -123,8 +123,6 @@ def create_text_image(text, image_export=False, **kwargs):
             line_w = line_width(size)
             last_line_w = line_w
 
-            # Fix: preserve newlines
-            #lines = textwrap.wrap(msg, width=line_w)
             lines = []
             for line in msg.splitlines():
                 cur_lines = textwrap.wrap(line, width=line_w)
@@ -161,8 +159,6 @@ def create_text_image(text, image_export=False, **kwargs):
     font = load_font(size)
     font_w, font_h = font.getsize(text)
     
-    # Fix: preserve newlines
-    #lines = textwrap.wrap(text, width=line_w)
     lines = []
     for line in text.splitlines():
         cur_lines = textwrap.wrap(line, width=line_w)


### PR DESCRIPTION
This PR does keep track of all the lines while wrapping the text over multiple lines.

This means, that a text can be printed which has newlines in it. This fixes #35.